### PR TITLE
New end point to delete sighting

### DIFF
--- a/api/Controllers/SightingReportsController.cs
+++ b/api/Controllers/SightingReportsController.cs
@@ -3,6 +3,7 @@ using WhaleSpottingBackend.Models.Request;
 
 
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace WhaleSpottingBackend.Controllers
 {
@@ -35,6 +36,25 @@ namespace WhaleSpottingBackend.Controllers
             }
 
             return Ok(new { message = "Your sighting report has been sucessfully submitted and is pending review." });
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpDelete("{id}")]
+        public IActionResult DeleteById(int id) {
+            
+            try 
+            {
+                _sightingReports.DeleteReport(id);
+            }
+            catch (ArgumentException ex)
+            {
+                return NotFound(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, ex.Message);
+            }
+            return Ok(new { message = "Your report has been sucessfully rejected and deleted from the table." });
         }
     }
 }

--- a/api/Repositories/SightingReportsRepo.cs
+++ b/api/Repositories/SightingReportsRepo.cs
@@ -7,6 +7,8 @@ namespace WhaleSpottingBackend.Repositories
     public interface ISightingReportsRepo
     {
         void CreateReport(SightingReport newReport);
+        SightingReport GetSightingById(int sightingId);
+        void DeleteReport(SightingReport report);
 
     }
 
@@ -23,6 +25,23 @@ namespace WhaleSpottingBackend.Repositories
         public void CreateReport(SightingReport newReport)
         {
             _context.SightingReports.Add(newReport);
+            _context.SaveChanges();
+        }
+
+        public SightingReport GetSightingById(int sightingId)
+        {
+            var sightingReport = _context.SightingReports
+                                    .FirstOrDefault(sighting => sighting.Id == sightingId);
+            if (sightingReport == null)
+            {
+                throw new ArgumentException($"Sighting report with id {sightingId} not found");
+            }
+            return sightingReport;
+        }
+
+        public void DeleteReport(SightingReport report)
+        {
+            _context.SightingReports.Remove(report);
             _context.SaveChanges();
         }
     }

--- a/api/Services/SightingReportsService.cs
+++ b/api/Services/SightingReportsService.cs
@@ -7,6 +7,7 @@ namespace WhaleSpottingBackend.Services;
 public interface ISightingReportsService
 {
     void CreateReport(CreateSightingReportRequest newReport);
+    void DeleteReport(int id);
 }
 
 public class SightingReportsService : ISightingReportsService
@@ -33,5 +34,17 @@ public class SightingReportsService : ISightingReportsService
         };
         _sightingReports.CreateReport(report);
     }
+
+    public void DeleteReport(int id)
+    {
+        var postToDelete = _sightingReports.GetSightingById(id);
+        if (postToDelete.Status == "Pending") { 
+        _sightingReports.DeleteReport(postToDelete);
+        }
+        else {
+            throw new ArgumentException($"Sighting report with id {id} is already approved");
+        }
+    }
+
 
 }


### PR DESCRIPTION
# Title

[Feature] Delete a pending sighting BE
[#14](https://github.com/techswitch-learners/whale-watching-june-25/issues/14)

## Describe your changes
Added a new end point to delete a pending sighting
Only Admin can access the resource

## How Has This Been Tested?
Tested in swagger without the code to authorize admin 

## Screenshots (if appropriate):

