### PR TITLE
Login endpoint

### DIFF
--- a/api/Controllers/AccountsLogin.cs
+++ b/api/Controllers/AccountsLogin.cs
@@ -1,0 +1,40 @@
+using WhaleSpottingBackend.Services;
+using WhaleSpottingBackend.Models.Request;
+using WhaleSpottingBackend.Database;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using WhaleSpottingBackend.Models.Database;
+using Microsoft.AspNetCore.Identity.Data;
+
+namespace WhaleSpottingBackend.Controllers;
+
+[ApiController]
+[Route("/accounts")]
+public class AccountsLoginController : ControllerBase
+{
+    private readonly UserManager<User> _userManager;
+    private readonly SignInManager<User> _signInManager;
+
+    public AccountsLoginController(SignInManager<User> signInManager, UserManager<User> userManager)
+    {
+        _signInManager = signInManager;
+        _userManager = userManager;
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login([FromBody] LoginRequest request)
+    {
+        var user = await _userManager.FindByEmailAsync(request.Email);
+        if (user == null)
+        {
+            return Unauthorized("Invalid Email");
+        }
+
+        var result = await _signInManager.PasswordSignInAsync(user, request.Password, isPersistent: false, lockoutOnFailure: false);
+        if (!result.Succeeded)
+        {
+            return Unauthorized("Invalid Password");
+        }
+        return Ok(new { message = "Login successful" });
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -45,6 +45,6 @@ app.UseAuthorization();
 
 app.MapControllers();
 
-app.MapIdentityApi<User>();
+//app.MapIdentityApi<User>();
 
 app.Run();


### PR DESCRIPTION
# Title

## Issue ticket number and link
[Feature] Create User Login Endpoint
 #27 

## Describe your changes
* Added an AccountsLogin Controller that has a custom API endpoint for login. It uses Identity's signinManager and userManager and can be accessed in the backend through /accounts/login.
* Set locked out to false so that user is not locked out of their account for wrong passwords and set isPersistent to false so that when a browser session ends, a login is logged out (done to ensure no issues when testing)
* Commented out "app.MapIdentityApi<User>();" line in program.cs because this line registered the default Identity API endpoints (like /login, /register, /logout, etc.) and we wanted to replace the login end point with a custom endpoint. Have chosen to comment it out instead of delete in case we want to look at other Identity endpoints.

## How Has This Been Tested?
Through Swagger using the Admins credentials.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/6caa777f-406b-40cd-b9c1-983c8464b7b4)
![image](https://github.com/user-attachments/assets/e0274a78-6b69-4b9a-b9ba-9a3b53b698b6)
