### PR TITLE
Sign up form styling

### DIFF
--- a/ui/src/components/SignUp/SignUp.scss
+++ b/ui/src/components/SignUp/SignUp.scss
@@ -1,9 +1,5 @@
 @import "../../styles/Constants";
 
-h1 {
-  @include header;  
-}
-
 form {      
   padding: 0 80px;
 }

--- a/ui/src/components/SignUp/SignUp.scss
+++ b/ui/src/components/SignUp/SignUp.scss
@@ -1,9 +1,5 @@
 @import "../../styles/Constants";
 
-#root, main {
-  background-color: $lightBlueBackground;
-}
-
 h1 {
   @include header;  
 }
@@ -22,10 +18,16 @@ input {
   width: 200px;
 }
 
+input:focus {
+    outline: 3px solid $tealBackground;
+    box-shadow: 0 0 10px $tealBackground;
+  }
+
 button {
   margin: 24px auto;
   justify-content: center;
-  width: 100%;    
+  width: 100%;
+  background-color: $blueBackground;    
 }
 
 .error-message {    

--- a/ui/src/components/SignUp/SignUp.scss
+++ b/ui/src/components/SignUp/SignUp.scss
@@ -1,54 +1,36 @@
 @import "../../styles/Constants";
 
+#root, main {
+  background-color: $lightBlueBackground;
+}
+
 h1 {
   @include header;  
 }
 
-.sign-up-form {      
-  display: flex;
-  flex-flow: column;
-  align-content: flex-start;
-  padding: 40px 120px;
+form {      
+  padding: 0 80px;
 }
 
-label{
+label {
   @include labelFormInput;
-  display:flex;
-  flex-direction: column;
-  flex-grow: 1;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 4px;
-  margin: 5px 0;
-  border-radius: 3px;
+  margin: 10px 0;
 }
 
- .input  {
-  @include labelFormInput;
-  display:flex;
-  flex-direction: column;
-  flex-grow: 1;
-  align-items: flex-start;
-  justify-content: space-between;
-  margin-bottom: 12px;
-  border-radius: 3px;
-}
-
-.label{
-  display: inline-flex;
+input {
+  margin: 0;
+  width: 200px;
 }
 
 button {
-  @include primaryButton;
-  display:flex;
   margin: 24px auto;
-  width: fit-content;
-  padding: 10px 10px;       
+  justify-content: center;
+  width: 100%;    
 }
 
 .error-message {    
   @include error;
-  margin: 12px 0;
+  margin: 0;
   width: 200px;
   font-size: 12px;
 }
@@ -61,4 +43,14 @@ button {
 
 .password {
   margin-bottom: 0;
+}
+
+@media (max-width: 425px) {
+  form {
+    padding: 0;
+  }
+
+  input {
+    height: 32px;
+  }
 }

--- a/ui/src/components/SignUp/SignUp.tsx
+++ b/ui/src/components/SignUp/SignUp.tsx
@@ -81,7 +81,7 @@ export function SignUpForm(): JSX.Element {
                 ...inputError,
                 username: "Usernames must be between 2 and 15 characters and can include full stops and underscores"
             });
-            setStatus(FormStatusEnum.Error);
+            setStatus(FormStatusEnum.Ready);
             return;
         }
 
@@ -140,7 +140,7 @@ export function SignUpForm(): JSX.Element {
 
     return (
             <form onSubmit={validateForm}>
-                <label className="label" htmlFor="username">Username
+                <label className="label" htmlFor="username">Username*
                 <input
                     value={formInput.username}
                     onChange={({target}) => {
@@ -155,7 +155,7 @@ export function SignUpForm(): JSX.Element {
                 <p className="error-message">{formError.username}</p>
                   </label>
 
-                <label className="label" htmlFor="email">Email
+                <label className="label" htmlFor="email">Email*
                 <input
                     value={formInput.email}
                     onChange={({target}) => {
@@ -171,7 +171,7 @@ export function SignUpForm(): JSX.Element {
                 <p className="error-message">{formError.email}</p>
                   </label>
 
-                <label className="label" htmlFor="password">Password
+                <label className="label" htmlFor="password">Password*
                 <input
                     value={formInput.password}
                     onChange={({target}) => {
@@ -197,7 +197,7 @@ export function SignUpForm(): JSX.Element {
                 <p className="error-message">{formError.password}</p>
                   </label>
 
-                <label className="label confirm-pw" htmlFor="confirmPassword">Confirm password
+                <label className="label confirm-pw" htmlFor="confirmPassword">Confirm password*
                 <input
                     value={formInput.confirmPassword}
                     onChange={({target}) => {

--- a/ui/src/components/SignUp/SignUp.tsx
+++ b/ui/src/components/SignUp/SignUp.tsx
@@ -65,7 +65,7 @@ export function SignUpForm(): JSX.Element {
             [name]: value,
         })
     }
-    
+
     const validateForm = (event: FormEvent) => {
         event.preventDefault();
         setStatus(FormStatusEnum.Submitting);
@@ -184,7 +184,6 @@ export function SignUpForm(): JSX.Element {
                     className="input password"
                     placeholder="Enter a secure password"
                 />
-
                     <small>
                         Password strength:{' '}
                             <span style={{
@@ -213,7 +212,7 @@ export function SignUpForm(): JSX.Element {
                   </label>
 
                 <label className="label" htmlFor="submit">
-                <button className="submit-button" type="submit" value="Submit" disabled={status === "SUBMITTING"}>Sign Up</button>
+                <button className="submit-button" type="submit" value="Submit" id="submit" disabled={status === "SUBMITTING"}>Sign Up</button>
                 {status === "SUBMITTING" && <p className="info-message">Hold tight your details are surfing the waves!</p>}
                 {status === "ERROR" && <p className="error-message">Something went wrong! Please try again.</p>}
                 </label>

--- a/ui/src/pages/SignUp/SignUpPage.scss
+++ b/ui/src/pages/SignUp/SignUpPage.scss
@@ -1,3 +1,8 @@
 .title {
     padding: 0;
 }
+
+.page {
+    padding: 40px;
+    border-radius: 20px;
+}

--- a/ui/src/pages/SignUp/SignUpPage.scss
+++ b/ui/src/pages/SignUp/SignUpPage.scss
@@ -1,0 +1,3 @@
+.title {
+    padding: 0;
+}

--- a/ui/src/pages/SignUp/SignUpPage.tsx
+++ b/ui/src/pages/SignUp/SignUpPage.tsx
@@ -1,6 +1,7 @@
 import { Page } from "../Page/Page";
 import { JSX} from "react";
 import { SignUpForm } from "../../components/SignUp/SignUp";
+import "./SignUpPage.scss";
 
 export function SignUp(): JSX.Element {
   return (


### PR DESCRIPTION
# Update sign-up form view

## Issue ticket number and link
#50 

## Describe your changes
- Removed unnecessary styling
- Corrected a small typo on line 84 of `ui/src/components/SignUp/SignUp.tsx` that led to an error being shown when it shouldn't
- Added new styles to improve the display of the form
- Updated the form labels with an * to show they are required
- Make the inputs larger for a small screen size
- Add style sheet for the Sign Up Page to fix padding issue

## How Has This Been Tested?
- Tested in the browser and checked at varying screen sizes

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/7cfc5298-a092-417e-bc7d-c5747269b151)
![image](https://github.com/user-attachments/assets/b88622ed-c632-4b5e-a213-df1c5a497204)