### PR TITLE
Secure Admin API

### DIFF
--- a/api/Controllers/SightingReportsController.cs
+++ b/api/Controllers/SightingReportsController.cs
@@ -52,6 +52,8 @@ namespace WhaleSpottingBackend.Controllers
             return Ok(new { message = "Your sighting report has been successfully submitted and is pending review." });
         }
 
+
+        [Authorize(Roles = "Admin")]
         [HttpPatch("{id}")]
         public IActionResult ApproveSighting(int id)
         {
@@ -71,6 +73,7 @@ namespace WhaleSpottingBackend.Controllers
 
         }
         
+         [Authorize(Roles = "Admin")]
         [HttpDelete("{id}")]
         public IActionResult DeleteById(int id) {
 
@@ -92,5 +95,6 @@ namespace WhaleSpottingBackend.Controllers
             }
             return Ok(new { message = "Your report has been sucessfully rejected and deleted from the table." });
         }
+        
     }
 }

--- a/ui/src/api/ApiClient.ts
+++ b/ui/src/api/ApiClient.ts
@@ -142,7 +142,8 @@ export async function login(email: string, password: string): Promise<{isAdmin: 
 
 export async function deleteWhaleSighting(id: number): Promise<void> {
     const response = await fetch(`http://localhost:5067/sightingreports/${id}`, {
-        method: "DELETE"
+        method: "DELETE",
+        credentials: "include"
     });
     if (!response.ok) {
         throw new Error(await response.text());
@@ -151,7 +152,8 @@ export async function deleteWhaleSighting(id: number): Promise<void> {
 
 export async function approveWhaleSighting(id: number): Promise<void> {
     const response = await fetch(`http://localhost:5067/sightingreports/${id}`, {
-        method: "PATCH"
+        method: "PATCH",
+        credentials: "include"
     });
     if (!response.ok) {
         throw new Error(await response.text());


### PR DESCRIPTION
# Title
Secure Admin API
## Issue ticket number and link
[(https://github.com/techswitch-learners/whale-watching-june-25/issues/80)]

## Describe your changes
Updated the deleteWhaleSighting and approveWhaleSighting methods in ApiClient.ts  to have "credentials: "include" included in the header of the api calls
Updated  the ApproveSighting and DeleteById methods in SightReportsController.cs to have "[Authorize(Roles = "Admin")]" on the top of the methods for admin authorization.

## How Has This Been Tested?
Tested from the frontend and see if admin is able to approve and deleted pending sightings.
Tested from swagger and see if approving and deleting sightings can be done without logging in as an admin user.

## Screenshots (if appropriate):
<img width="3530" height="1925" alt="Screenshot 2025-07-10 144620" src="https://github.com/user-attachments/assets/6ee94232-f0cf-4505-9fcb-d86108385317" />
<img width="3577" height="1938" alt="Screenshot 2025-07-10 144633" src="https://github.com/user-attachments/assets/98037929-6981-4c9a-bc33-7d6727e773fc" />

