### PR TITLE
Hide view photo button when URL is empty string

### DIFF
--- a/ui/src/components/Admin/ListPendingSightings.tsx
+++ b/ui/src/components/Admin/ListPendingSightings.tsx
@@ -95,7 +95,7 @@ export function ListPendingSightings() {
                                     <td className="hide-on-mobile">{sightingReport.longitude}</td>
                                     <td>{sightingReport.userName}</td>
                                     <td className="hide-on-mobile">{sightingReport.description}</td>
-                                    <td className="hide-on-mobile">{sightingReport.imageUrl != null ? <button className="view-photo-button" onClick={() => handleClickShowImage(sightingReport.imageUrl)}>View</button> : <p>No photo available</p>}</td>
+                                    <td className="hide-on-mobile">{sightingReport.imageUrl !== null && sightingReport.imageUrl !== "" ? <button className="view-photo-button" onClick={() => handleClickShowImage(sightingReport.imageUrl)}>View</button> : <p>No photo available</p>}</td>
                                 </tr>
                                 <tr>
                                     <td className="accept-delete-button hide-on-mobile" colSpan={4} >

--- a/ui/src/components/ApprovedSightingsList/ApprovedSightingsList.tsx
+++ b/ui/src/components/ApprovedSightingsList/ApprovedSightingsList.tsx
@@ -134,7 +134,7 @@ export function ApprovedSightingsList() {
                                                 <td className="hide-on-mobile">{sightingReport.longitude}</td>
                                                 <td>{sightingReport.userName}</td>
                                                 <td className="hide-on-mobile">{sightingReport.description}</td>
-                                                <td className="hide-on-mobile">{sightingReport.imageUrl != null ? <button className="view-photo-button" onClick={() => handleClickShowImage(sightingReport.imageUrl)}>View</button> : <p>No photo available</p>}</td>
+                                                <td className="hide-on-mobile">{sightingReport.imageUrl !== null && sightingReport.imageUrl !== "" ? <button className="view-photo-button" onClick={() => handleClickShowImage(sightingReport.imageUrl)}>View</button> : <p>No photo available</p>}</td>
                                             </tr>
                                         )
                                     ) : (


### PR DESCRIPTION
# Hide view photo button when URL is empty string

## Issue ticket number and link
#83 

## Describe your changes
- add logic to check for empty string to both admin and approved sightings components

## How Has This Been Tested?
- tested by adding sighting with empty string image url